### PR TITLE
chore: align EnvironmentFile path with standardized env file

### DIFF
--- a/deploy/systemd/webitel-webrtc-rec.service
+++ b/deploy/systemd/webitel-webrtc-rec.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=always
-EnvironmentFile=/etc/default/webitel-webrtc-rec.env
+EnvironmentFile=/etc/default/webitel-webrtc-rec
 TimeoutStartSec=0
 ExecStart=/usr/local/bin/webitel-webrtc-rec server
 


### PR DESCRIPTION
Drops the `.env` suffix: `EnvironmentFile=/etc/default/webitel-webrtc-rec` to match the standardized package dst. Prevents a fresh-install mismatch once the reusable-configs standardization lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)