### PR TITLE
ref(systemd): provide temp dir via CacheDirectory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,7 @@ ID=dev
 BIND_ADDRESS=:5001
 WEBRTC_UDP_PORT_RANGE=4000-4500
 
+CACHE_TEMP_DIR=/var/cache/webitel-webrtc-rec
+
 CONSUL=127.0.0.1:8500
 DATA_SOURCE=postgres://user:password@127.0.0.1:5432/webitel?sslmode=disable

--- a/deploy/systemd/webitel-webrtc-rec.service
+++ b/deploy/systemd/webitel-webrtc-rec.service
@@ -9,6 +9,7 @@ Type=simple
 User=webitel
 Group=webitel
 LogsDirectory=webitel
+CacheDirectory=webitel-webrtc-rec
 
 EnvironmentFile=/etc/default/webitel-webrtc-rec
 EnvironmentFile=-/etc/default/webitel-otel
@@ -35,7 +36,6 @@ PrivateTmp=yes
 NoExecPaths=/
 ExecPaths=/usr/local/bin/webitel-webrtc-rec
 ExecPaths=/usr/bin/ffmpeg
-ReadWritePaths=/var/lib/webitel/webrtc-temp
 
 # Process isolation
 PrivateDevices=yes


### PR DESCRIPTION
Provision the service temp directory via systemd `CacheDirectory` (auto-created under `/var/cache`, owned by webitel, writable under `ProtectSystem=strict`) and set the env default accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)