### PR TITLE
ref(deploy): backport systemd hardening to v26.04

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,7 @@ ID=dev
 BIND_ADDRESS=:5001
 WEBRTC_UDP_PORT_RANGE=4000-4500
 
+CACHE_TEMP_DIR=/var/cache/webitel-webrtc-rec
+
 CONSUL=127.0.0.1:8500
 DATA_SOURCE=postgres://user:password@127.0.0.1:5432/webitel?sslmode=disable

--- a/.github/workflows/pull-request-deliver.yml
+++ b/.github/workflows/pull-request-deliver.yml
@@ -16,6 +16,10 @@ jobs:
   version:
     name: Version
     uses: webitel/reusable-workflows/.github/workflows/_version.yml@v2
+    permissions:
+      contents: read
+      id-token: write
+
     if: |
       github.event.workflow_run.head_repository.fork == false &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,7 +51,7 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-webrtc-rec.service dst=/etc/systemd/system/webitel-webrtc-rec.service type=config
-        src=.env.example dst=/etc/default/webitel-webrtc-rec type=config
+        src=.env.example dst=/etc/default/webitel-webrtc-rec type=config mode=0640
         
 
       scripts: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,7 +59,7 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-webrtc-rec.service dst=/etc/systemd/system/webitel-webrtc-rec.service type=config
-        src=.env.example dst=/etc/default/webitel-webrtc-rec type=config
+        src=.env.example dst=/etc/default/webitel-webrtc-rec type=config mode=0640
         
 
       package-depends: ffmpeg

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ Thumbs.db
 .env.*
 *.env
 !.env.example
-!.env.otel.example
+!.env.*.example
 !.env.sample
 !example.env
 env

--- a/deploy/debian/postinst.sh
+++ b/deploy/debian/postinst.sh
@@ -49,7 +49,7 @@ create_user() {
 # and run under `set -e`: a failing hook aborts the install, which is the
 # correct behaviour when e.g. a required certificate cannot be generated.
 run_postinst_hooks() {
-    local hook_dir="/usr/lib/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
+    local hook_dir="/usr/lib/webitel/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
     [ -d "$hook_dir" ] || return 0
 
     local hook

--- a/deploy/systemd/webitel-webrtc-rec.service
+++ b/deploy/systemd/webitel-webrtc-rec.service
@@ -1,13 +1,71 @@
 [Unit]
-Description=WebRTC recorder startup process
-After=network.target
+Description=WebRTC recorder
+After=network.target consul.service rabbitmq-server.service postgresql.service
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 Type=simple
-Restart=always
+User=webitel
+Group=webitel
+LogsDirectory=webitel
+
 EnvironmentFile=/etc/default/webitel-webrtc-rec
-TimeoutStartSec=0
+EnvironmentFile=-/etc/default/webitel-otel
+EnvironmentFile=-/etc/default/webitel
 ExecStart=/usr/local/bin/webitel-webrtc-rec server
 
+Restart=on-failure
+RestartSec=5
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStartSec=0
+TimeoutStopSec=30
+LimitNOFILE=64000
+LimitNPROC=4096
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=webitel-webrtc-rec
+
+# Filesystem isolation
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoExecPaths=/
+ExecPaths=/usr/local/bin/webitel-webrtc-rec
+ExecPaths=/usr/bin/ffmpeg
+ReadWritePaths=/var/lib/webitel/webrtc-temp
+
+# Process isolation
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectProc=invisible
+ProcSubset=pid
+NoNewPrivileges=yes
+PrivateMounts=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectHostname=yes
+SystemCallArchitectures=native
+UMask=0077
+
+# Capabilities & syscalls
+CapabilityBoundingSet=CAP_NET_ADMIN
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+SystemCallFilter=~@obsolete
+SystemCallErrorNumber=EPERM
+
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/deploy/systemd/webitel-webrtc-rec.service
+++ b/deploy/systemd/webitel-webrtc-rec.service
@@ -9,6 +9,7 @@ Type=simple
 User=webitel
 Group=webitel
 LogsDirectory=webitel
+CacheDirectory=webitel-webrtc-rec
 
 EnvironmentFile=/etc/default/webitel-webrtc-rec
 EnvironmentFile=-/etc/default/webitel-otel
@@ -35,7 +36,6 @@ PrivateTmp=yes
 NoExecPaths=/
 ExecPaths=/usr/local/bin/webitel-webrtc-rec
 ExecPaths=/usr/bin/ffmpeg
-ReadWritePaths=/var/lib/webitel/webrtc-temp
 
 # Process isolation
 PrivateDevices=yes


### PR DESCRIPTION
Backports this cycle's deployment work to the `v26.04` release branch via cherry-pick (deploy/ + env examples + .gitignore + workflow package-contents only).

- standardized & hardened systemd unit
- config moved to `/etc/default/` env-file layering
- temp dir via `CacheDirectory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)